### PR TITLE
Recurse through controls to register widgets

### DIFF
--- a/Robust.Client/UserInterface/UIScreen.cs
+++ b/Robust.Client/UserInterface/UIScreen.cs
@@ -131,11 +131,11 @@ public abstract class UIScreen : LayoutContainer
     {
         base.ChildAdded(newChild);
 
+        RegisterChildren(newChild);
+
         if (newChild is not UIWidget widget) return;
         if (!_widgets.TryAdd(widget.GetType(), widget))
             throw new Exception("Tried to add duplicate widget to screen!");
-
-        RegisterChildren(newChild);
     }
 
     private void RegisterChildren(Control control)
@@ -159,9 +159,9 @@ public abstract class UIScreen : LayoutContainer
     protected override void ChildRemoved(Control child)
     {
         base.ChildRemoved(child);
+        RemoveChildren(child);
         if (child is not UIWidget widget) return;
         _widgets.Remove(child.GetType());
-        RemoveChildren(child);
     }
 
     private void RemoveChildren(Control control)

--- a/Robust.Client/UserInterface/UIScreen.cs
+++ b/Robust.Client/UserInterface/UIScreen.cs
@@ -142,6 +142,8 @@ public abstract class UIScreen : LayoutContainer
     {
         foreach (var child in control.Children)
         {
+            RegisterChildren(child);
+
             if (child is not UIWidget widget)
             {
                 continue;
@@ -166,6 +168,8 @@ public abstract class UIScreen : LayoutContainer
     {
         foreach (var child in control.Children)
         {
+            RemoveChildren(child);
+
             if (child is not UIWidget widget)
             {
                 continue;

--- a/Robust.Client/UserInterface/UIScreen.cs
+++ b/Robust.Client/UserInterface/UIScreen.cs
@@ -99,7 +99,7 @@ public abstract class UIScreen : LayoutContainer
 
     public void AddWidget(UIWidget widget)
     {
-
+        AddChild(widget);
     }
 
     public T? GetWidget<T>() where T : UIWidget, new()
@@ -130,9 +130,28 @@ public abstract class UIScreen : LayoutContainer
     protected override void ChildAdded(Control newChild)
     {
         base.ChildAdded(newChild);
+
         if (newChild is not UIWidget widget) return;
         if (!_widgets.TryAdd(widget.GetType(), widget))
             throw new Exception("Tried to add duplicate widget to screen!");
+
+        RegisterChildren(newChild);
+    }
+
+    private void RegisterChildren(Control control)
+    {
+        foreach (var child in control.Children)
+        {
+            if (child is not UIWidget widget)
+            {
+                continue;
+            }
+
+            if (!_widgets.TryAdd(widget.GetType(), widget))
+            {
+                throw new Exception("Tried to add duplicate widget to screen!");
+            }
+        }
     }
 
     protected override void ChildRemoved(Control child)
@@ -140,6 +159,20 @@ public abstract class UIScreen : LayoutContainer
         base.ChildRemoved(child);
         if (child is not UIWidget widget) return;
         _widgets.Remove(child.GetType());
+        RemoveChildren(child);
+    }
+
+    private void RemoveChildren(Control control)
+    {
+        foreach (var child in control.Children)
+        {
+            if (child is not UIWidget widget)
+            {
+                continue;
+            }
+
+            _widgets.Remove(widget.GetType());
+        }
     }
 
     protected void OnLoaded()


### PR DESCRIPTION
I was messing around with this branch, and I found that if I laid out widgets as children of a control in a UIScreen, those widgets wouldn't be registered. I don't know if this is idiomatic, but I feel like people will eventually try to lay out widgets in this matter, since you can create UIScreens in XAML.